### PR TITLE
ECS-6549 Build and release IOCs for Rocky 9

### DIFF
--- a/RELEASE_SITE
+++ b/RELEASE_SITE
@@ -1,10 +1,10 @@
 BASE_MODULE_VERSION = R7.0.3.1-2.0
-EPICS_SITE_TOP      = /cds/group/pcds/epics
-EPICS_MODULES       = $(EPICS_SITE_TOP)/$(BASE_MODULE_VERSION)/modules
+EPICS_SITE_TOP = /cds/group/pcds/epics
+EPICS_MODULES = $(EPICS_SITE_TOP)/$(BASE_MODULE_VERSION)/modules
 ifeq ($(origin EPICS_HOST_ARCH), undefined)
 EPICS_HOST_ARCH     := $(shell $(EPICS_SITE_TOP)/base/$(BASE_MODULE_VERSION)/startup/EpicsHostArch)
 endif
-PSPKG_ROOT          = /cds/group/pcds/pkg_mgr
+PSPKG_ROOT = /cds/group/pcds/pkg_mgr
 
 $(info Setting BASE_MODULE_VERSION to $(BASE_MODULE_VERSION) in $(lastword $(MAKEFILE_LIST)))
 

--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -6,10 +6,10 @@ include $(TOP)/RELEASE_SITE
 # Define the version of modules needed by
 # IOC apps or other Support apps
 # ===============================================================
-ASYN_MODULE_VERSION          = R4.39-1.0.0
-AUTOSAVE_MODULE_VERSION      = R5.8-2.1.0
-IOCADMIN_MODULE_VERSION      = R3.1.16-1.3.2
-STREAMDEVICE_MODULE_VERSION  = R2.8.9-1.2.0
+ASYN_MODULE_VERSION = R4.39-1.0.2
+AUTOSAVE_MODULE_VERSION = R5.11-2.0.0
+IOCADMIN_MODULE_VERSION = R3.1.16-1.4.0
+STREAMDEVICE_MODULE_VERSION = R2.8.9-1.2.2
 
 # ============================================================
 # External Support module path definitions

--- a/configure/RULES.copy
+++ b/configure/RULES.copy
@@ -1,2 +1,0 @@
-# RULES.copy
--include $(EPICS_BASE)/configure/RULES.copy


### PR DESCRIPTION
Updated configuration files for Rocky 9 migration.

Test IOC output
```
(pcds-6.0.1) janeliu@psbuild-rocky9-01:iocs $ telnet ctl-tst-dev-03 30001
Trying 172.21.148.78...
Connected to ctl-tst-dev-03.
Escape character is '^]'.
@@@ Welcome to procServ (procServ Process Server 2.9.0-1.1.0)
@@@ Use ^X to kill the child, auto restart mode is ON, use ^T to toggle auto restart
@@@ procServ server PID: 731961
@@@ Server startup directory: /tmp
@@@ Child startup directory: /tmp
@@@ Child "ioc-tst-gsd-mspace" started as: startProc
@@@ Child log file: unable to open log file /reg/d/iocData/ioc-tst-gsd-mspace/iocInfo/ioc.log
@@@ Child "ioc-tst-gsd-mspace" PID: 731977
@@@ procServ server started at: Tue Nov  4 10:50:53 2025
@@@ Child "ioc-tst-gsd-mspace" started at: Tue Nov  4 10:50:54 2025
@@@ 0 user(s) and 0 logger(s) connected (plus you)
@@@ Current time: Tue Nov  4 10:51:35 2025
@@@ Child process is shutting down, a new one will be restarted shortly
@@@ ^R or ^X restarts the child, ^Q quits the server

@@@ @@@ @@@ @@@ @@@
@@@ Received a sigChild for process 731977. The process was killed by signal 9
@@@ Restarting child "ioc-tst-gsd-mspace"
@@@    (as startProc)
@@@ The PID of new child "ioc-tst-gsd-mspace" is: 733278
@@@ @@@ @@@ @@@ @@@
#!/cds/home/j/janeliu/git/iocs/ioc-common-generic_streamdevice/bin/rhel9-x86_64/gsd
epicsEnvSet( "IOCNAME",   "ioc-tst-gsd-mspace" )
epicsEnvSet( "ENGINEER",  "Jane Liu (janeliu-slac)" )
epicsEnvSet( "LOCATION",  "Somewhere" )
epicsEnvSet( "IOCSH_PS1", "ioc-tst-gsd-mspace> " )
epicsEnvSet( "IOC_PV",    "IOC:TST:GSD:01" )
epicsEnvSet( "IOCTOP",    "/cds/home/j/janeliu/git/iocs/ioc-common-generic_streamdevice" )
epicsEnvSet( "STREAM_PROTOCOL_PATH", "/cds/home/j/janeliu/git/iocs/ioc-common-generic_streamdevice/app/srcProtocol" )
< envPaths
epicsEnvSet("IOC","ioc-tst-gsd-mspace")
epicsEnvSet("TOP","/cds/home/j/janeliu/git/iocs/ioc-common-generic_streamdevice")
epicsEnvSet("EPICS_SITE_TOP","/cds/group/pcds/epics")
epicsEnvSet("EPICS_MODULES","/cds/group/pcds/epics/R7.0.3.1-2.0/modules")
epicsEnvSet("PSPKG_ROOT","/cds/group/pcds/pkg_mgr")
epicsEnvSet("ASYN","/cds/group/pcds/epics/R7.0.3.1-2.0/modules/asyn/R4.39-1.0.2")
epicsEnvSet("AUTOSAVE","/cds/group/pcds/epics/R7.0.3.1-2.0/modules/autosave/R5.11-2.1.1")
epicsEnvSet("IOCADMIN","/cds/group/pcds/epics/R7.0.3.1-2.0/modules/iocAdmin/R3.1.16-1.4.0")
epicsEnvSet("STREAMDEVICE","/cds/group/pcds/epics/R7.0.3.1-2.0/modules/streamdevice/R2.8.9-1.2.2")
epicsEnvSet("EPICS_BASE","/cds/group/pcds/epics/base/R7.0.3.1-2.0")
epicsEnvSet("TOP", "/cds/home/j/janeliu/git/iocs/ioc-common-generic_streamdevice/children/build")
cd("/cds/home/j/janeliu/git/iocs/ioc-common-generic_streamdevice")
# Run common startup commands for linux soft IOC's
< /reg/d/iocCommon/All/pre_linux.cmd
#==============================================================
#
#  Abs:  Soft IOC pre-startup initialization (Production)
#
#  Name: pre_linux.cmd
#
#  Facility: LCLS Controls
#
#  Auth: 27-Jul-2009, Bruce Hill (bhill)
#  Rev:  dd-mmm-yyyy, Reviewer's Name (USERNAME)
#                       Based on soft_pre_st.cmd from LCLS
#  Mod:
#       dd-mmm-yyyy, Firstname Lastname (USERNAME):
#         comment
#
#==============================================================
#
# Time...
epicsEnvSet("EPICS_TS_NTP_INET","psntp.slac.stanford.edu")
# iocLogClient...
epicsEnvSet("EPICS_IOC_LOG_FILE_LIMIT","1000000")
epicsEnvSet("EPICS_IOC_LOG_FILE_COMMAND","")
# iocLogClient: Send log messages to logstash:
epicsEnvSet("EPICS_IOC_LOG_INET", "ctl-logsrv01.pcdsn")
epicsEnvSet("EPICS_IOC_LOG_PORT", "7004")
# The following prefix is *required* for logstash to know which IOC is sending
# the message.  This *cannot* be modified without changes to the logstash
# configuration.
iocLogPrefix("IOC=ioc-tst-gsd-mspace ")
# caPutLog: Send caPutLog messages to logstash:
epicsEnvSet("EPICS_CAPUTLOG_HOST", "ctl-logsrv01.pcdsn")
epicsEnvSet("EPICS_CAPUTLOG_PORT", "7011")
epicsEnvSet("EPICS_CA_PUT_LOG_ADDR", "ctl-logsrv01.pcdsn:7011")
# TODO: Need a way to conditionally set these based on the host so ioc-xcs-misc1 and others don't send CA traffic over fez
# Channel Access...
epicsEnvSet("EPICS_CA_ADDR_LIST","")
epicsEnvSet("EPICS_CA_REPEATER_PORT","5065")
epicsEnvSet("EPICS_CA_SERVER_PORT","5064")
epicsEnvSet("EPICS_CA_CONN_TMO","10.0")
epicsEnvSet("EPICS_CA_BEACON_PERIOD","5.0")
epicsEnvSet("EPICS_CA_MAX_SEARCH_PERIOD","60.0")
epicsEnvSet("EPICS_CA_AUTO_ADDR_LIST","YES")
epicsEnvSet("EPICS_CAS_INTF_ADDR_LIST","")
epicsEnvSet("EPICS_CAS_BEACON_ADDR_LIST","")
epicsEnvSet("EPICS_CAS_AUTO_BEACON_ADDR_LIST","")
epicsEnvSet("EPICS_CAS_SERVER_PORT","")
epicsEnvSet("EPICS_CAS_BEACON_PORT","")
epicsEnvSet("EPICS_CAS_BEACON_PERIOD","5.0")
epicsEnvSet("EPICS_CA_MAX_ARRAY_BYTES", "4000000")
# Let's add this for pvaccess support.  If it's not compiled in, it can't hurt,
# and if you really want it off, you can do that in the st.cmd after including
# this.
epicsEnvSet( "EPICS_PVA_AUTO_ADDR_LIST",         "TRUE" )
epicsEnvSet( "EPICS_PVAS_AUTO_BEACON_ADDR_LIST", "TRUE" )
# Enable ioc error logging
setIocLogDisable 0
## Register all support components
dbLoadDatabase( "dbd/gsd.dbd" )
gsd_registerRecordDeviceDriver(pdbbase)
Warning: IOC is booting with TOP = "/cds/home/j/janeliu/git/iocs/ioc-common-generic_streamdevice/children/build"
          but was built with TOP = "/cds/home/j/janeliu/git/iocs/ioc-common-generic_streamdevice"
## Set up IOC/hardware links -- LAN connection
##############################################################
drvAsynIPPortConfigure( "bus0", "gst-tst-01:10000", 0, 0, 0 )
2025/11/04 10:51:37.056 bus0 -1 autoConnect could not connect: Unknown host "gst-tst-01"
asynSetTraceIOMask( "bus0", 0, 0x1 ) # logging for normal operation
## Load record instances
dbLoadRecords( "db/iocSoft.db", "IOC=IOC:TST:GSD:01")
dbLoadRecords( "db/save_restoreStatus.db", "P=IOC:TST:GSD:01:")
dbLoadRecords( "db/gsd.db", "BASE=TST:GSD:01, DEV=bus0" )
Can't set "TST:GSD:01:MOTOR:X_POS.SCAN" to "0.5 second" Extraneous characters
Error at or before ")" in file "db/gsd.db" line 44
## Setup autosave
set_savefile_path( "/reg/d/iocData/ioc-tst-gsd-mspace/autosave" )
set_requestfile_path( "/cds/home/j/janeliu/git/iocs/ioc-common-generic_streamdevice/children/build/autosave" )
# Also look in the iocData autosave folder for auto generated req files
set_requestfile_path( "/reg/d/iocData/ioc-tst-gsd-mspace/autosave" )
save_restoreSet_status_prefix( "IOC:TST:GSD:01:" )
save_restoreSet_IncompleteSetsOk( 1 )
save_restoreSet_DatedBackupFiles( 1 )
set_pass0_restoreFile( "autoSettings.sav" )
set_pass0_restoreFile( "ioc-tst-gsd-mspace.sav" )
# Initialize the IOC and start processing records
iocInit()
Starting iocInit
############################################################################
## EPICS R7.0.3.1-2.0.1
## EPICS Base built Oct 17 2024
############################################################################
2025/11/04 10:51:37.773623 _main_ gsd.proto line 28: Field '$1:Y_POS' not found
2025/11/04 10:51:37.773636 _main_ gsd.proto line 28: in format string: "%($1:Y_POS)f, MOTOR Z: %($1:Z_POS)f "
2025/11/04 10:51:37.773645 _main_ gsd.proto line 28: in command 'in'
2025/11/04 10:51:37.773650 _main_ gsd.proto line 26: in protocol 'get_motor_positions'
2025/11/04 10:51:37.773655 _main_ while compiling protocol 'GET_MOTOR_POSITIONS(TST:GSD:01)' for 'TST:GSD:01:MOTOR:X_POS'
2025/11/04 10:51:37.773659 _main_ TST:GSD:01:MOTOR:X_POS: Protocol parse error
2025/11/04 10:51:37.773663 _main_ TST:GSD:01:MOTOR:X_POS: Record initialization failed
Successfully locked memory using mlockAll
iocRun: All initialization complete
# Create autosave files from info directives
makeAutosaveFileFromDbInfo( "/reg/d/iocData/ioc-tst-gsd-mspace/autosave/autoSettings.req", "autosaveFields" )
# Start autosave backups
create_monitor_set( "autoSettings.req", 5, "" )
create_monitor_set( "ioc-tst-gsd-mspace.req", 5, "" )
# All IOCs should dump some common info after initial startup.
< /reg/d/iocCommon/All/post_linux.cmd
# Let's Get EPICS version:
iocshCmd("coreRelease > /reg/d/iocData/ioc-tst-gsd-mspace/iocInfo/IOC.epicsVersion")
# Let's Get EPICS environment:
iocshCmd("epicsEnvShow > /reg/d/iocData/ioc-tst-gsd-mspace/iocInfo/IOC.epicsEnvShow")
# Dump a list of all PVs to a file on the Boot Server:
# The pvs name will be written to a file along with its record type.
# The location on the boot server follows:
# ${IOC_DATA}/${IOC}/iocInfo
iocshCmd("dbl '' RTYP > /reg/d/iocData/ioc-tst-gsd-mspace/iocInfo/IOC.pvlist")
iocshCmd("dbl '' DTYP > /reg/d/iocData/ioc-tst-gsd-mspace/iocInfo/IOC.DTYP")
# Let's get the hardware info from the IOC to the boot server
iocshCmd("dbhcr > /reg/d/iocData/ioc-tst-gsd-mspace/iocInfo/IOC.dbhcr")
iocshCmd("dbior > /reg/d/iocData/ioc-tst-gsd-mspace/iocInfo/IOC.dbior")
# Let's get alarm ready Data
iocshCmd("dbl '' 'RTYP DTYP SCAN HHSV HSV LSV LLSV OSV ZSV HYST HIHI LOLO HIGH LOW' >/reg/d/iocData/ioc-tst-gsd-mspace/iocInfo/IOC.pvAlarm")
# Let's get input/output data
iocshCmd("dbl '' 'RTYP DTYP SCAN INP OUT OMSL DOL TSE' >/reg/d/iocData/ioc-tst-gsd-mspace/iocInfo/IOC.pvIO")
# Let's get scaling info
iocshCmd("dbl '' 'RTYP DTYP SCAN HOPR LOPR DRVH DRVL EGUF EGUL LINR AOFF ASLO ESLO' >/reg/d/iocData/ioc-tst-gsd-mspace/iocInfo/IOC.pvScale")
ioc-tst-gsd-mspace.sav: 13 of 13 PV's connected
autoSettings.sav: 1 of 1 PV's connected
# Let's get the remaining interesting PV fields:
iocshCmd("dbl '' 'RTYP DTYP SCAN ASG IOVA IVOV ADEL MDEL SMOO' >/reg/d/iocData/ioc-tst-gsd-mspace/iocInfo/IOC.pvMisc")
# CA report
iocshCmd("casr(2) > /reg/d/iocData/ioc-tst-gsd-mspace/iocInfo/IOC.casr")
# Db CA Connections
iocshCmd("dbcar(0,1) > /reg/d/iocData/ioc-tst-gsd-mspace/iocInfo/IOC.dbcar")
# dbDumpRecord report
iocshCmd("dbDumpRecord > /reg/d/iocData/ioc-tst-gsd-mspace/iocInfo/IOC.dbDumpRecord")
# Post Startup Complete, the IRMIS crawler appreciates your cooperation.
ioc-tst-gsd-mspace>
```
