### PR TITLE
Clean up errors in ioc.sub-req

### DIFF
--- a/iocBoot/templates/ioc.sub-req
+++ b/iocBoot/templates/ioc.sub-req
@@ -2,18 +2,13 @@
 ## iocAdmin PV's on this IOC
 
 # Generate IOC autosave request
-file autosave_iocAdmin.tpl-arch
-{
-    { IOC = "$$IOC_PV" }
-}
-
-file archive_SR.tpl-arch
+file autosave_iocAdmin.tpl-req
 {
     { IOC = "$$IOC_PV" }
 }
 
 $$LOOP(DEVICE)
-file gsd.archive
+file gsd.req
 {
     { BASE = "$$BASE" }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Fixes some errors in `ioc.sub-req`, particularly references to `.archive` files. 

Does not add a corresponding `autosave_iocAdmin.tpl-req` file because it doesn't exist. 

## Motivation and Context
Closes #6 

## How Has This Been Tested?
These are the changes I made to a different `streamDevice` IOC that I'm making based on this template. With my modifications, the template builds without errors, silent or otherwise. 

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
This PR. 

## Pre-merge checklist
- [x] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
