### PR TITLE
Envpaths fix

### DIFF
--- a/children/ioc-tst-gsd-01.cfg
+++ b/children/ioc-tst-gsd-01.cfg
@@ -2,7 +2,7 @@ RELEASE=$$UP(PATH)
 ENGINEER=Michael Browne (mcbrowne)
 LOCATION=Somewhere
 IOC_PV=IOC:TST:GSD:01
-ARCH=rhel7-x86_64
+TARGET_ARCH=rhel9-x86_64
 
 #
 # Required parameters:

--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -6,10 +6,10 @@ include $(TOP)/RELEASE_SITE
 # Define the version of modules needed by
 # IOC apps or other Support apps
 # ===============================================================
-ASYN_MODULE_VERSION          = R4.39-1.0.0
-AUTOSAVE_MODULE_VERSION      = R5.8-2.1.0
-IOCADMIN_MODULE_VERSION      = R3.1.16-1.3.2
-STREAMDEVICE_MODULE_VERSION  = R2.8.9-1.2.0
+ASYN_MODULE_VERSION          = R4.39-1.0.2
+AUTOSAVE_MODULE_VERSION      = R5.11-2.1.1
+IOCADMIN_MODULE_VERSION      = R3.1.16-1.4.0
+STREAMDEVICE_MODULE_VERSION  = R2.8.9-1.2.2
 
 # ============================================================
 # External Support module path definitions

--- a/iocBoot/templates/Makefile
+++ b/iocBoot/templates/Makefile
@@ -6,9 +6,7 @@ TOP = $(IOC_APPL_TOP)
 endif
 
 include $(TOP)/configure/CONFIG
-ifndef ARCH
-ARCH = rhel7-x86_64
-endif
+ARCH = $$IF(TARGET_ARCH,$$TARGET_ARCH,rhel7-x86_64)
 
 INSTALL_LOCATION = ../..
 INSTALL_LOCATION_BIN = $(TOP)/bin

--- a/iocBoot/templates/st.cmd
+++ b/iocBoot/templates/st.cmd
@@ -1,4 +1,4 @@
-#!$$IOCTOP/bin/$$IF(ARCH,$$ARCH,linux-86_64)/gsd
+#!$$IOCTOP/bin/$$IF(TARGET_ARCH,$$TARGET_ARCH,rhel7-x86_64)/gsd
 
 epicsEnvSet( "IOCNAME",	  "$$IOCNAME" )
 epicsEnvSet( "ENGINEER",  "$$ENGINEER" )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Changes EPICS releases to make this IOC compatible with Rocky9. Fixes a build issue with envPaths. 

## Motivation and Context
See the discussion in the pcds channel here: https://slac.slack.com/archives/C2PNS4Q74/p1753809750979079

Closes #8 

## How Has This Been Tested?
Tested on `psbuild-rocky9`:

Pre PR: (note missing `envPaths` after build)

```
Setting BASE_MODULE_VERSION to R7.0.3.1-2.0 in /cds/home/t/tjohnson/trunk/common/generic_streamdevice_gh/RELEASE_SITE
make -C ./ioc-tst-gsd-01 install 
make[4]: Entering directory '/cds/home/t/tjohnson/trunk/common/generic_streamdevice_gh/children/build/iocBoot/ioc-tst-gsd-01'
Setting BASE_MODULE_VERSION to R7.0.3.1-2.0 in /cds/home/t/tjohnson/trunk/common/generic_streamdevice_gh/RELEASE_SITE
perl -CSD /cds/group/pcds/epics/base/R7.0.3.1-2.0/bin/rhel9-x86_64/mkmf.pl -m ioc-tst-gsd-01.req -I. -I.. -I../O.Common -I../../autosave -I/cds/home/t/tjohnson/trunk/common/generic_streamdevice_gh/autosave -I/cds/group/pcds/epics/R7.0.3.1-2.0/modules/autosave -I/cds/group/pcds/epics/R7.0.3.1-2.0/modules/autosave/R5.11-2.1.1/autosave -I/cds/group/pcds/epics/R7.0.3.1-2.0/modules/iocAdmin/R3.1.16-1.4.0/autosave ioc-tst-gsd-01.req ioc-tst-gsd-01.sub-req 
Inflating autosave request from ioc-tst-gsd-01.sub-req
/cds/group/pcds/epics/base/R7.0.3.1-2.0/bin/rhel9-x86_64/msi   -I. -I.. -I../O.Common -I../../autosave -I/cds/home/t/tjohnson/trunk/common/generic_streamdevice_gh/autosave -I/cds/group/pcds/epics/R7.0.3.1-2.0/modules/autosave -I/cds/group/pcds/epics/R7.0.3.1-2.0/modules/autosave/R5.11-2.1.1/autosave -I/cds/group/pcds/epics/R7.0.3.1-2.0/modules/iocAdmin/R3.1.16-1.4.0/autosave -Sioc-tst-gsd-01.sub-req > ioc-tst-gsd-01.req
perl -CSD /cds/group/pcds/epics/base/R7.0.3.1-2.0/bin/rhel9-x86_64/mkmf.pl -m ioc-tst-gsd-01.archive -I. -I.. -I../O.Common -I../../archive -I/cds/home/t/tjohnson/trunk/common/generic_streamdevice_gh/archive -I/cds/group/pcds/epics/R7.0.3.1-2.0/modules/autosave/R5.11-2.1.1/archive -I/cds/group/pcds/epics/R7.0.3.1-2.0/modules/iocAdmin/R3.1.16-1.4.0/archive ioc-tst-gsd-01.archive ioc-tst-gsd-01.sub-arch 
Inflating archive file from ioc-tst-gsd-01.sub-arch
/cds/group/pcds/epics/base/R7.0.3.1-2.0/bin/rhel9-x86_64/msi  -V -I. -I.. -I../O.Common -I../../archive -I/cds/home/t/tjohnson/trunk/common/generic_streamdevice_gh/archive -I/cds/group/pcds/epics/R7.0.3.1-2.0/modules/autosave/R5.11-2.1.1/archive -I/cds/group/pcds/epics/R7.0.3.1-2.0/modules/iocAdmin/R3.1.16-1.4.0/archive -Sioc-tst-gsd-01.sub-arch > ioc-tst-gsd-01.archive
Setting BASE_MODULE_VERSION to R7.0.3.1-2.0 in /cds/home/t/tjohnson/trunk/common/generic_streamdevice_gh/RELEASE_SITE
Installing archive file ../../archive/ioc-tst-gsd-01.archive
Installing autosave file ../../autosave/ioc-tst-gsd-01.req
make[4]: Leaving directory '/cds/home/t/tjohnson/trunk/common/generic_streamdevice_gh/children/build/iocBoot/ioc-tst-gsd-01'
make[3]: Leaving directory '/cds/home/t/tjohnson/trunk/common/generic_streamdevice_gh/children/build/iocBoot'
make[2]: Leaving directory '/cds/home/t/tjohnson/trunk/common/generic_streamdevice_gh/children/build'
make[1]: warning:  Clock skew detected.  Your build may be incomplete.
make[1]: Leaving directory '/cds/home/t/tjohnson/trunk/common/generic_streamdevice_gh/children'
[tjohnson@psbuild-rocky9-01:~/trunk/common/generic_streamdevice_gh]$ less children/build/iocBoot/ioc-tst-gsd-01/envPaths 
children/build/iocBoot/ioc-tst-gsd-01/envPaths: No such file or directory
[tjohnson@psbuild-rocky9-01:~/trunk/common/generic_streamdevice_gh]$ cat children/ioc-tst-gsd-01.cfg 
RELEASE=$$UP(PATH)
ENGINEER=Michael Browne (mcbrowne)
LOCATION=Somewhere
IOC_PV=IOC:TST:GSD:01
ARCH=rhel9-x86_64

#
# Required parameters:
#     BASE - PV prefix
#     PORT - Port name (number if IP address specified, name of device in /dev otherwise)
# Optional parameters:
#     HOST - IP address
#     ASYNTRACE - Verbose asyn output if true.
#     TRACEFILE - Name of file to save asyn trace in (in iocInfo directory).
DEVICE(BASE=TST:GSD:01,HOST=gst-tst-01,PORT=10000)
[tjohnson@psbuild-rocky9-01:~/trunk/common/generic_streamdevice_gh]$
```


Post-pr (we have `envPaths`!)

```
make -C ./ioc-tst-gsd-01 install 
make[4]: Entering directory '/cds/home/t/tjohnson/trunk/common/generic_streamdevice_gh/children/build/iocBoot/ioc-tst-gsd-01'
Setting BASE_MODULE_VERSION to R7.0.3.1-2.0 in /cds/home/t/tjohnson/trunk/common/generic_streamdevice_gh/RELEASE_SITE
perl -CSD /cds/group/pcds/epics/base/R7.0.3.1-2.0/bin/rhel9-x86_64/mkmf.pl -m ioc-tst-gsd-01.req -I. -I.. -I../O.Common -I../../autosave -I/cds/home/t/tjohnson/trunk/common/generic_streamdevice_gh/autosave -I/cds/group/pcds/epics/R7.0.3.1-2.0/modules/autosave -I/cds/group/pcds/epics/R7.0.3.1-2.0/modules/autosave/R5.11-2.1.1/autosave -I/cds/group/pcds/epics/R7.0.3.1-2.0/modules/iocAdmin/R3.1.16-1.4.0/autosave ioc-tst-gsd-01.req ioc-tst-gsd-01.sub-req 
Inflating autosave request from ioc-tst-gsd-01.sub-req
/cds/group/pcds/epics/base/R7.0.3.1-2.0/bin/rhel9-x86_64/msi   -I. -I.. -I../O.Common -I../../autosave -I/cds/home/t/tjohnson/trunk/common/generic_streamdevice_gh/autosave -I/cds/group/pcds/epics/R7.0.3.1-2.0/modules/autosave -I/cds/group/pcds/epics/R7.0.3.1-2.0/modules/autosave/R5.11-2.1.1/autosave -I/cds/group/pcds/epics/R7.0.3.1-2.0/modules/iocAdmin/R3.1.16-1.4.0/autosave -Sioc-tst-gsd-01.sub-req > ioc-tst-gsd-01.req
perl -CSD /cds/group/pcds/epics/base/R7.0.3.1-2.0/bin/rhel9-x86_64/mkmf.pl -m ioc-tst-gsd-01.archive -I. -I.. -I../O.Common -I../../archive -I/cds/home/t/tjohnson/trunk/common/generic_streamdevice_gh/archive -I/cds/group/pcds/epics/R7.0.3.1-2.0/modules/autosave/R5.11-2.1.1/archive -I/cds/group/pcds/epics/R7.0.3.1-2.0/modules/iocAdmin/R3.1.16-1.4.0/archive ioc-tst-gsd-01.archive ioc-tst-gsd-01.sub-arch 
Inflating archive file from ioc-tst-gsd-01.sub-arch
/cds/group/pcds/epics/base/R7.0.3.1-2.0/bin/rhel9-x86_64/msi  -V -I. -I.. -I../O.Common -I../../archive -I/cds/home/t/tjohnson/trunk/common/generic_streamdevice_gh/archive -I/cds/group/pcds/epics/R7.0.3.1-2.0/modules/autosave/R5.11-2.1.1/archive -I/cds/group/pcds/epics/R7.0.3.1-2.0/modules/iocAdmin/R3.1.16-1.4.0/archive -Sioc-tst-gsd-01.sub-arch > ioc-tst-gsd-01.archive
Setting BASE_MODULE_VERSION to R7.0.3.1-2.0 in /cds/home/t/tjohnson/trunk/common/generic_streamdevice_gh/RELEASE_SITE
perl -CSD /cds/group/pcds/epics/base/R7.0.3.1-2.0/bin/rhel9-x86_64/convertRelease.pl -T /cds/home/t/tjohnson/trunk/common/generic_streamdevice_gh envPaths
Installing archive file ../../archive/ioc-tst-gsd-01.archive
Installing autosave file ../../autosave/ioc-tst-gsd-01.req
make[4]: Leaving directory '/cds/home/t/tjohnson/trunk/common/generic_streamdevice_gh/children/build/iocBoot/ioc-tst-gsd-01'
make[3]: Leaving directory '/cds/home/t/tjohnson/trunk/common/generic_streamdevice_gh/children/build/iocBoot'
make[2]: Leaving directory '/cds/home/t/tjohnson/trunk/common/generic_streamdevice_gh/children/build'
make[1]: Leaving directory '/cds/home/t/tjohnson/trunk/common/generic_streamdevice_gh/children'
[tjohnson@psbuild-rocky9-01:~/trunk/common/generic_streamdevice_gh]$ cat children/build/iocBoot/ioc-tst-gsd-01/envPaths 
epicsEnvSet("IOC","ioc-tst-gsd-01")
epicsEnvSet("TOP","/cds/home/t/tjohnson/trunk/common/generic_streamdevice_gh")
epicsEnvSet("EPICS_SITE_TOP","/cds/group/pcds/epics")
epicsEnvSet("EPICS_MODULES","/cds/group/pcds/epics/R7.0.3.1-2.0/modules")
epicsEnvSet("PSPKG_ROOT","/cds/group/pcds/pkg_mgr")
epicsEnvSet("ASYN","/cds/group/pcds/epics/R7.0.3.1-2.0/modules/asyn/R4.39-1.0.2")
epicsEnvSet("AUTOSAVE","/cds/group/pcds/epics/R7.0.3.1-2.0/modules/autosave/R5.11-2.1.1")
epicsEnvSet("IOCADMIN","/cds/group/pcds/epics/R7.0.3.1-2.0/modules/iocAdmin/R3.1.16-1.4.0")
epicsEnvSet("STREAMDEVICE","/cds/group/pcds/epics/R7.0.3.1-2.0/modules/streamdevice/R2.8.9-1.2.2")
epicsEnvSet("EPICS_BASE","/cds/group/pcds/epics/base/R7.0.3.1-2.0")
[tjohnson@psbuild-rocky9-01:~/trunk/common/generic_streamdevice_gh]$ 
```

## Where Has This Been Documented?
This PR and Slack chat. 

## Pre-merge checklist
- [ ] Code works interactively
- [ ] Code contains descriptive docstrings, including context and API
